### PR TITLE
Broken dependencies in Nix-conf fixed

### DIFF
--- a/lemmingtools/nix-support/megaparsec-6.4.1.nix
+++ b/lemmingtools/nix-support/megaparsec-6.4.1.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, base, bytestring, case-insensitive, containers
+, criterion, deepseq, hspec, hspec-expectations, mtl
+, parser-combinators, QuickCheck, scientific, stdenv, text
+, transformers, weigh
+}:
+mkDerivation {
+  pname = "megaparsec";
+  version = "6.4.1";
+  sha256 = "de40015dac65c2707a0bd65b7974da4d0cc00593d8bdebc0d58319761ee21370";
+  revision = "2";
+  editedCabalFile = "0vh4l2kl9nfxlr8l82qicldybwiv6vbksi3jdk0xjzxmkvgm0jnf";
+  libraryHaskellDepends = [
+    base bytestring case-insensitive containers deepseq mtl
+    parser-combinators scientific text transformers
+  ];
+  testHaskellDepends = [
+    base bytestring containers hspec hspec-expectations mtl QuickCheck
+    scientific text transformers
+  ];
+  benchmarkHaskellDepends = [ base criterion deepseq text weigh ];
+  homepage = "https://github.com/mrkkrp/megaparsec";
+  description = "Monadic parser combinators";
+  license = stdenv.lib.licenses.bsd2;
+}

--- a/lemmingtools/nix-support/parser-combinators-0.4.0.nix
+++ b/lemmingtools/nix-support/parser-combinators-0.4.0.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, stdenv }:
+mkDerivation {
+  pname = "parser-combinators";
+  version = "0.4.0";
+  sha256 = "b124e9411de085972e4d9ae8254299e8e773e964b2798eb400d5cf6814f8f3ab";
+  libraryHaskellDepends = [ base ];
+  homepage = "https://github.com/mrkkrp/parser-combinators";
+  description = "Lightweight package providing commonly useful parser combinators";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/lemmingtools/shell.nix
+++ b/lemmingtools/shell.nix
@@ -1,4 +1,5 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
+with nixpkgs.haskell.lib;
 
 let
 
@@ -26,12 +27,13 @@ let
       };
 
   haskellPackages = if compiler == "default"
-                       then pkgs.haskellPackages
+                       then pkgs.haskell.packages.ghc822
                        else pkgs.haskell.packages.${compiler};
 
-  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+  parser-combinators = haskellPackages.callPackage ./nix-support/parser-combinators-0.4.0.nix {};
+  megaparsec = dontCheck (haskellPackages.callPackage ./nix-support/megaparsec-6.4.1.nix { parser-combinators = parser-combinators; });
 
-  drv = variant (haskellPackages.callPackage f {});
+  drv = haskellPackages.callPackage f { megaparsec = megaparsec; };
 
 in
 


### PR DESCRIPTION
Some dependencies are not correctly selected by nix-build in the wrong environment, the conf is now more strict about these with custom nix-builds.