### PR TITLE
Add optparse-applicative as dependency to lemmingtools

### DIFF
--- a/lemmingtools/nix-support/optparse-applicative-0.14.2.0.nix
+++ b/lemmingtools/nix-support/optparse-applicative-0.14.2.0.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, ansi-wl-pprint, base, bytestring, process
+, QuickCheck, stdenv, transformers, transformers-compat
+}:
+mkDerivation {
+  pname = "optparse-applicative";
+  version = "0.14.2.0";
+  sha256 = "e1341e9831c7b10332d1b29cfa966a80d46b476bb52d99d50bdb53eb770d7f30";
+  libraryHaskellDepends = [
+    ansi-wl-pprint base process transformers transformers-compat
+  ];
+  testHaskellDepends = [ base bytestring QuickCheck ];
+  homepage = "https://github.com/pcapriotti/optparse-applicative";
+  description = "Utilities and combinators for parsing command line options";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/lemmingtools/shell.nix
+++ b/lemmingtools/shell.nix
@@ -6,7 +6,7 @@ let
   inherit (nixpkgs) pkgs;
 
   f = { mkDerivation, base, bytestring, megaparsec
-      , postgresql-simple, stdenv, text
+      , postgresql-simple, stdenv, text, optparse-applicative
       }:
       mkDerivation {
         pname = "lemmingtools";
@@ -18,7 +18,7 @@ let
           base bytestring megaparsec postgresql-simple text
         ];
         executableHaskellDepends = [
-          base bytestring megaparsec postgresql-simple text
+          base bytestring megaparsec postgresql-simple text optparse-applicative
         ];
         testHaskellDepends = [ base ];
         homepage = "https://github.com/githubuser/lemmingtools#readme";
@@ -30,10 +30,15 @@ let
                        then pkgs.haskell.packages.ghc822
                        else pkgs.haskell.packages.${compiler};
 
+
+  optparse-applicative = haskellPackages.callPackage ./nix-support/optparse-applicative-0.14.2.0.nix {};
   parser-combinators = haskellPackages.callPackage ./nix-support/parser-combinators-0.4.0.nix {};
   megaparsec = dontCheck (haskellPackages.callPackage ./nix-support/megaparsec-6.4.1.nix { parser-combinators = parser-combinators; });
 
-  drv = haskellPackages.callPackage f { megaparsec = megaparsec; };
+  drv = haskellPackages.callPackage f {
+    megaparsec = megaparsec;
+    optparse-applicative = optparse-applicative;
+  };
 
 in
 


### PR DESCRIPTION
Added a nix-expression for optparse-applicative 0.14.2.0 and included it in the build expression. 